### PR TITLE
Modded audio output stuff

### DIFF
--- a/audio/mixer_paths.xml
+++ b/audio/mixer_paths.xml
@@ -308,14 +308,14 @@
     <!-- Volume controls -->
     <ctl name="HPHL Volume" value="19" />
     <ctl name="HPHR Volume" value="19" />
-    <ctl name="EAR PA Gain" value="POS_1P8_DB" />
+    <ctl name="EAR PA Gain" value="POS_2P0_DB" />
     <ctl name="EAR PA Boost" value="ENABLE" />
 
-    <ctl name="RX1 Digital Volume" value="84" />
-    <ctl name="RX2 Digital Volume" value="84" />
+    <ctl name="RX1 Digital Volume" value="90" />
+    <ctl name="RX2 Digital Volume" value="90" />
     <ctl name="RX3 Digital Volume" value="84" />
     <ctl name="RX4 Digital Volume" value="84" />
-    <ctl name="RX5 Digital Volume" value="88" />
+    <ctl name="RX5 Digital Volume" value="90" />
     <ctl name="ADC1 Volume" value="4" />
     <ctl name="ADC2 Volume" value="4" />
     <ctl name="ADC3 Volume" value="4" />


### PR DESCRIPTION
Should not break audio, just boost earpeice and speaker gains. Beware of very loud audio from apps like whatscrap.

This is especially for low incall audio and tinny speaker output. This should give a rich output at even 50% volume.